### PR TITLE
feat(android): add debug and pro build variants with adaptive launcher icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,35 @@ Useful Gradle tasks and flags:
 
 Note that most tasks that are not specific to a single project can be run with `name:` prefix, where the `name` should be replaced with the ID of a specific project.
 For example, `core:clean` removes `build` folder only from the `core` project.
+
+## Android Variants (`debug` and `pro`)
+
+The `android` module now defines two main build variants you can work with:
+
+- `debug`: internal testing build (`applicationId` becomes `es.masmultimedia.debug`, no minify, debuggable, app name `SimpleSurvivor Debug`, orange adaptive launcher icon).
+- `pro`: production-oriented build (`applicationId` stays `es.masmultimedia`, minify + resource shrink enabled, app name `SimpleSurvivor Pro`, blue/gold adaptive launcher icon).
+
+### In Android Studio
+
+1. Open **Build Variants** tool window.
+2. For module `android`, choose `debug` while developing.
+3. Switch to `pro` before generating release-ready artifacts.
+
+### Gradle Commands
+
+```bash
+./gradlew :android:assembleDebug
+./gradlew :android:installDebug
+./gradlew :android:runDebug
+
+./gradlew :android:assemblePro
+./gradlew :android:installPro
+./gradlew :android:runPro
+```
+
+### Notes
+
+- `debug` and `pro` can coexist on the same device because `debug` uses a different package suffix.
+- `debug` and `pro` also have separate launcher names and icons, so they are easy to distinguish on-device.
+- `release` still exists for compatibility, but the recommended production path is `pro`.
+- You can check the active mode from `BuildConfig.IS_PRO_BUILD` if you need runtime switches.

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -5,7 +5,8 @@
   <application
       android:allowBackup="true"
       android:fullBackupContent="true"
-      android:icon="@drawable/ic_launcher"
+      android:icon="@mipmap/ic_launcher"
+      android:roundIcon="@mipmap/ic_launcher_round"
       android:isGame="true"
       android:appCategory="game"
       android:label="@string/app_name"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,3 @@
-
 buildscript {
   repositories {
     mavenCentral()
@@ -11,6 +10,11 @@ apply plugin: 'kotlin-android'
 android {
   namespace "es.masmultimedia"
   compileSdk 34
+
+  buildFeatures {
+    buildConfig true
+  }
+
   sourceSets {
     main {
       manifest.srcFile 'AndroidManifest.xml'
@@ -44,14 +48,35 @@ android {
     coreLibraryDesugaringEnabled true
   }
   buildTypes {
+    debug {
+      applicationIdSuffix '.debug'
+      versionNameSuffix '-debug'
+      debuggable true
+      minifyEnabled false
+      buildConfigField 'boolean', 'IS_PRO_BUILD', 'false'
+    }
+
+    pro {
+      initWith release
+      matchingFallbacks = ['release']
+      debuggable false
+      minifyEnabled true
+      shrinkResources true
+      buildConfigField 'boolean', 'IS_PRO_BUILD', 'true'
+      proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+      signingConfig signingConfigs.debug
+    }
+
     release {
       minifyEnabled true
-      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+      shrinkResources true
+      debuggable false
+      buildConfigField 'boolean', 'IS_PRO_BUILD', 'true'
+      proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
     }
   }
 
   kotlin.compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
-  
 }
 
 repositories {
@@ -118,7 +143,29 @@ tasks.matching { it.name.contains("merge") && it.name.contains("JniLibFolders") 
   packageTask.dependsOn 'copyAndroidNatives'
 }
 
-tasks.register('run', Exec) {
+tasks.register('runDebug', Exec) {
+  def path
+  def localProperties = project.file("../local.properties")
+  if (localProperties.exists()) {
+    Properties properties = new Properties()
+    localProperties.withInputStream { instr ->
+      properties.load(instr)
+    }
+    def sdkDir = properties.getProperty('sdk.dir')
+    if (sdkDir) {
+      path = sdkDir
+    } else {
+      path = "$System.env.ANDROID_SDK_ROOT"
+    }
+  } else {
+    path = "$System.env.ANDROID_SDK_ROOT"
+  }
+
+  def adb = path + "/platform-tools/adb"
+  commandLine "$adb", 'shell', 'am', 'start', '-n', 'es.masmultimedia.debug/es.masmultimedia.android.AndroidLauncher'
+}
+
+tasks.register('runPro', Exec) {
   def path
   def localProperties = project.file("../local.properties")
   if (localProperties.exists()) {
@@ -138,6 +185,10 @@ tasks.register('run', Exec) {
 
   def adb = path + "/platform-tools/adb"
   commandLine "$adb", 'shell', 'am', 'start', '-n', 'es.masmultimedia/es.masmultimedia.android.AndroidLauncher'
+}
+
+tasks.register('run') {
+  dependsOn 'runDebug'
 }
 
 eclipse.project.name = appName + "-android"

--- a/android/res/drawable/ic_launcher_background.xml
+++ b/android/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+  <solid android:color="#111827" />
+</shape>
+

--- a/android/res/drawable/ic_launcher_foreground.xml
+++ b/android/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:gravity="center" android:width="72dp" android:height="72dp">
+    <shape android:shape="oval">
+      <solid android:color="#22C55E" />
+    </shape>
+  </item>
+  <item android:gravity="center" android:width="36dp" android:height="36dp">
+    <shape android:shape="oval">
+      <solid android:color="#FFFFFF" />
+    </shape>
+  </item>
+</layer-list>
+

--- a/android/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+  <background android:drawable="@drawable/ic_launcher_background" />
+  <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>
+

--- a/android/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+  <background android:drawable="@drawable/ic_launcher_background" />
+  <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>
+

--- a/android/src/debug/res/drawable/ic_launcher.xml
+++ b/android/src/debug/res/drawable/ic_launcher.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+  <item>
+    <shape android:shape="oval">
+      <solid android:color="#FF6D00" />
+    </shape>
+  </item>
+  <item android:gravity="center" android:width="52dp" android:height="52dp">
+    <shape android:shape="oval">
+      <solid android:color="#FFFFFF" />
+    </shape>
+  </item>
+  <item android:gravity="center" android:width="24dp" android:height="24dp">
+    <shape android:shape="oval">
+      <solid android:color="#FF6D00" />
+    </shape>
+  </item>
+</layer-list>
+

--- a/android/src/debug/res/drawable/ic_launcher_background.xml
+++ b/android/src/debug/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+  <solid android:color="#FF6D00" />
+</shape>
+

--- a/android/src/debug/res/drawable/ic_launcher_foreground.xml
+++ b/android/src/debug/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+  <!-- Spaceship body (center fuselage) -->
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="
+        M54,18
+        C54,18 44,34 42,50
+        L42,68
+        C42,68 46,72 54,72
+        C62,72 66,68 66,68
+        L66,50
+        C64,34 54,18 54,18
+        Z" />
+
+  <!-- Left wing -->
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="
+        M42,52
+        L28,68
+        L36,68
+        L42,62
+        Z" />
+
+  <!-- Right wing -->
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="
+        M66,52
+        L80,68
+        L72,68
+        L66,62
+        Z" />
+
+  <!-- Engine glow (bottom) -->
+  <path
+      android:fillColor="#FF6D00"
+      android:pathData="
+        M48,68
+        L50,82
+        L54,86
+        L58,82
+        L60,68
+        Z" />
+
+  <!-- Cockpit window -->
+  <path
+      android:fillColor="#FF6D00"
+      android:pathData="
+        M54,28
+        C51,28 49,31 49,34
+        C49,37 51,40 54,40
+        C57,40 59,37 59,34
+        C59,31 57,28 54,28
+        Z" />
+
+</vector>

--- a/android/src/debug/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/src/debug/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+  <background android:drawable="@drawable/ic_launcher_background" />
+  <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>
+

--- a/android/src/debug/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/src/debug/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+  <background android:drawable="@drawable/ic_launcher_background" />
+  <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>
+

--- a/android/src/debug/res/values/strings.xml
+++ b/android/src/debug/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="app_name">SimpleSurvivor Debug</string>
+</resources>
+

--- a/android/src/pro/res/drawable/ic_launcher.xml
+++ b/android/src/pro/res/drawable/ic_launcher.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+  <item>
+    <shape android:shape="oval">
+      <solid android:color="#0D47A1" />
+    </shape>
+  </item>
+  <item android:gravity="center" android:width="52dp" android:height="52dp">
+    <shape android:shape="oval">
+      <solid android:color="#FFD54F" />
+    </shape>
+  </item>
+  <item android:gravity="center" android:width="24dp" android:height="24dp">
+    <shape android:shape="oval">
+      <solid android:color="#0D47A1" />
+    </shape>
+  </item>
+</layer-list>
+

--- a/android/src/pro/res/drawable/ic_launcher_background.xml
+++ b/android/src/pro/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+</shape>
+  <solid android:color="#0D47A1" />
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">

--- a/android/src/pro/res/drawable/ic_launcher_foreground.xml
+++ b/android/src/pro/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+  <!-- Spaceship body (center fuselage) -->
+  <path
+      android:fillColor="#FFD54F"
+      android:pathData="
+        M54,18
+        C54,18 44,34 42,50
+        L42,68
+        C42,68 46,72 54,72
+        C62,72 66,68 66,68
+        L66,50
+        C64,34 54,18 54,18
+        Z" />
+
+  <!-- Left wing -->
+  <path
+      android:fillColor="#FFD54F"
+      android:pathData="
+        M42,52
+        L28,68
+        L36,68
+        L42,62
+        Z" />
+
+  <!-- Right wing -->
+  <path
+      android:fillColor="#FFD54F"
+      android:pathData="
+        M66,52
+        L80,68
+        L72,68
+        L66,62
+        Z" />
+
+  <!-- Engine glow (bottom) -->
+  <path
+      android:fillColor="#0D47A1"
+      android:pathData="
+        M48,68
+        L50,82
+        L54,86
+        L58,82
+        L60,68
+        Z" />
+
+  <!-- Cockpit window -->
+  <path
+      android:fillColor="#0D47A1"
+      android:pathData="
+        M54,28
+        C51,28 49,31 49,34
+        C49,37 51,40 54,40
+        C57,40 59,37 59,34
+        C59,31 57,28 54,28
+        Z" />
+
+</vector>

--- a/android/src/pro/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/src/pro/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+  <background android:drawable="@drawable/ic_launcher_background" />
+  <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>
+

--- a/android/src/pro/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/src/pro/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+  <background android:drawable="@drawable/ic_launcher_background" />
+  <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>
+

--- a/android/src/pro/res/values/strings.xml
+++ b/android/src/pro/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="app_name">SimpleSurvivor Pro</string>
+</resources>
+


### PR DESCRIPTION
Add two distinct build types to replace the single default Android build:

Build types:
- debug: internal testing build
  - applicationId suffix: .debug (coexists with pro on the same device)
  - versionName suffix: -debug
  - debuggable, no minification
  - BuildConfig.IS_PRO_BUILD = false
- pro: production build
  - applicationId: es.masmultimedia (clean, no suffix)
  - minifyEnabled + shrinkResources
  - BuildConfig.IS_PRO_BUILD = true
- release: kept for compatibility, inherits pro settings

Launcher icons (adaptive, mipmap-anydpi-v26):
- debug: orange background, white spaceship, orange engine/window
- pro: dark blue background, gold spaceship, blue engine/window
- Both use the same vector spaceship silhouette as foreground
- Fallback base icons kept in android/res for legacy devices

App names (per-variant strings.xml):
- debug: "SimpleSurvivor Debug"
- pro: "SimpleSurvivor Pro"

Gradle run tasks:
- runDebug: launches es.masmultimedia.debug
- runPro: launches es.masmultimedia
- run: delegates to runDebug by default

Documentation:
- README updated with variant overview, Gradle commands and notes